### PR TITLE
support optional timestamp param

### DIFF
--- a/lib/forecast_io/forecast.rb
+++ b/lib/forecast_io/forecast.rb
@@ -1,7 +1,7 @@
 module ForecastIO
   class Forecast < Request
-    def coordinates(latitude:, longitude:, **opts)
-      path = "#{latitude},#{longitude}"
+    def coordinates(latitude:, longitude:, time: nil, **opts)
+      path = [latitude, longitude, time].compact.join(",")
       path << "?#{build_query(opts)}" if opts.any?
       res = request(:get, path)
       build_forecast(res)


### PR DESCRIPTION
as per the docs, you can add an optional time param to get the weather at a specific time
`https://api.forecast.io/forecast/APIKEY/LATITUDE,LONGITUDE,TIME`
this PR allows you to do that
